### PR TITLE
[bugix] Fixed creating anchors crashing on multiplayer servers

### DIFF
--- a/src/main/java/com/leobeliik/extremesoundmuffler/gui/MainScreen.java
+++ b/src/main/java/com/leobeliik/extremesoundmuffler/gui/MainScreen.java
@@ -410,10 +410,8 @@ public class MainScreen extends GuiScreen implements ISoundLists, IColorsGui {
         if (anchor != null) {
             stringW = fontRendererObj.getStringWidth("Dimension: ");
             radius = anchor.getRadius() == 0 ? "" : String.valueOf(anchor.getRadius());
-            if (anchor.getDimension() != null) {
-                stringW += fontRendererObj.getStringWidth(anchor.getDimension());
-                dimensionName = anchor.getDimension();
-            }
+            stringW += fontRendererObj.getStringWidth(anchor.getDimensionName());
+            dimensionName = anchor.getDimensionName();
             drawRect(x - 5, y - 56, x + stringW + 6, y + 16, darkBG);
             drawString(fontRendererObj, "X: " + anchor.getX(), x + 1, y - 50, whiteText);
             drawString(fontRendererObj, "Y: " + anchor.getY(), x + 1, y - 40, whiteText);

--- a/src/main/java/com/leobeliik/extremesoundmuffler/utils/Anchor.java
+++ b/src/main/java/com/leobeliik/extremesoundmuffler/utils/Anchor.java
@@ -10,7 +10,6 @@ import net.minecraft.client.entity.EntityClientPlayerMP;
 import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Vec3;
-import net.minecraftforge.common.DimensionManager;
 
 import com.leobeliik.extremesoundmuffler.interfaces.ISoundLists;
 
@@ -18,7 +17,7 @@ public class Anchor {
 
     private final int id;
     private String name;
-    private String dimension;
+    private int dimensionId;
     private int radius;
     private SortedMap<String, Float> muffledSounds = new TreeMap<>();
     private Vec3 anchorPos;
@@ -28,12 +27,12 @@ public class Anchor {
         this.name = name;
     }
 
-    public Anchor(int id, String name, Vec3 anchorPos, String dimension, int radius,
+    public Anchor(int id, String name, Vec3 anchorPos, int dimensionId, int radius,
         SortedMap<String, Float> muffledSounds) {
         this.id = id;
         this.name = name;
         this.anchorPos = anchorPos;
-        this.dimension = dimension;
+        this.dimensionId = dimensionId;
         this.radius = radius;
         this.muffledSounds = muffledSounds;
     }
@@ -96,12 +95,19 @@ public class Anchor {
         return anchorPos == null ? 0 : (int) anchorPos.zCoord;
     }
 
-    public String getDimension() {
-        return dimension;
+    public int getDimensionId() {
+        return this.dimensionId;
     }
 
-    private void setDimension(String dimension) {
-        this.dimension = dimension;
+    public String getDimensionName() {
+        EntityClientPlayerMP player = Objects.requireNonNull(Minecraft.getMinecraft().thePlayer);
+        String name = player.worldObj.provider.getProviderForDimension(this.dimensionId)
+            .getDimensionName();
+        return name == null ? "???" : name;
+    }
+
+    private void setDimensionId(int id) {
+        this.dimensionId = id;
     }
 
     public void removeSound(ResourceLocation sound) {
@@ -111,16 +117,14 @@ public class Anchor {
     public void setAnchor() {
         EntityClientPlayerMP player = Objects.requireNonNull(Minecraft.getMinecraft().thePlayer);
         setAnchorPos((int) player.posX, (int) player.posY, (int) player.posZ);
-        setDimension(
-            DimensionManager.getProvider(player.dimension)
-                .getDimensionName());
+        setDimensionId(player.dimension);
         setRadius(this.getRadius() == 0 ? 32 : this.getRadius());
     }
 
     public void deleteAnchor() {
         setName("Anchor: " + this.getAnchorId());
         anchorPos = null;
-        setDimension(null);
+        setDimensionId(Integer.MIN_VALUE);
         setRadius(0);
         muffledSounds.clear();
     }
@@ -135,8 +139,7 @@ public class Anchor {
         for (Anchor anchor : ISoundLists.anchorList) {
             WorldClient world = Minecraft.getMinecraft().theWorld;
             if (anchor.getAnchorPos() != null && world != null
-                && world.provider.getDimensionName()
-                    .equals(anchor.getDimension())
+                && world.provider.dimensionId == anchor.getDimensionId()
                 && soundPos.distanceTo(anchor.getAnchorPos()) < anchor.getRadius()
                 && anchor.getMuffledSounds()
                     .containsKey(new ComparableResource(sound.getPositionedSoundLocation()))) {

--- a/src/main/java/com/leobeliik/extremesoundmuffler/utils/DataManager.java
+++ b/src/main/java/com/leobeliik/extremesoundmuffler/utils/DataManager.java
@@ -92,7 +92,7 @@ public class DataManager implements ISoundLists {
         anchorNBT.setInteger("X", (int) anchor.getAnchorPos().xCoord);
         anchorNBT.setInteger("Y", (int) anchor.getAnchorPos().yCoord);
         anchorNBT.setInteger("Z", (int) anchor.getAnchorPos().zCoord);
-        anchorNBT.setString("DIM", anchor.getDimension());
+        anchorNBT.setInteger("DIM", anchor.getDimensionId());
         anchorNBT.setInteger("RAD", anchor.getRadius());
         anchor.getMuffledSounds()
             .forEach((R, F) -> muffledNBT.setFloat(R.toString(), F));
@@ -116,7 +116,7 @@ public class DataManager implements ISoundLists {
                 nbt.getInteger("ID"),
                 nbt.getString("NAME"),
                 Vec3.createVectorHelper(nbt.getInteger("X"), nbt.getInteger("Y"), nbt.getInteger("Z")),
-                nbt.getString("DIM"),
+                nbt.getInteger("DIM"),
                 nbt.getInteger("RAD"),
                 muffledSounds);
         }


### PR DESCRIPTION
Caused by calling `DimensionManager.getProvider()` in `setAnchor()` which returns a `WorldServer` regardless of sidedness.

Also hardened `Anchor` class against possible issues with dimensions that are named the same thing by swapping to dimension IDs which are unique.